### PR TITLE
Pass CLI timeout to auto-detected MicroBitSerial.get_serial

### DIFF
--- a/microfs/main.py
+++ b/microfs/main.py
@@ -218,7 +218,7 @@ def _run_command(args: argparse.Namespace) -> None:
     if args.serial is not None:
         args.serial = MicroBitSerial(args.serial, timeout=args.timeout)
     else:
-        args.serial = MicroBitSerial.get_serial()
+        args.serial = MicroBitSerial.get_serial(timeout=args.timeout)
     with args.serial:
         _dispatch_command(args)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -40,12 +40,32 @@ def test_main_timeout() -> None:
         mock.patch(
             "microfs.main.MicroBitSerial.get_serial",
             return_value=mock_serial_class.return_value,
-        ),
+        ) as mock_get_serial,
     ):
         mock_serial_instance = mock_serial_class.return_value
         main()
         mock_ls.assert_called_once_with(mock_serial_instance)
         mock_print.assert_called_once_with("foo bar")
+        mock_get_serial.assert_called_once_with(timeout=10)
+
+
+def test_main_timeout_with_custom_value() -> None:
+    """Test that custom timeout is forwarded to device discovery."""
+    with (
+        mock.patch("sys.argv", ["ufs", "--timeout", "2.5", "ls"]),
+        mock.patch("microfs.main.ls", return_value=["foo"]) as mock_ls,
+        mock.patch("microfs.main.MicroBitSerial") as mock_serial_class,
+        mock.patch.object(builtins, "print") as mock_print,
+        mock.patch(
+            "microfs.main.MicroBitSerial.get_serial",
+            return_value=mock_serial_class.return_value,
+        ) as mock_get_serial,
+    ):
+        mock_serial_instance = mock_serial_class.return_value
+        main()
+        mock_ls.assert_called_once_with(mock_serial_instance)
+        mock_print.assert_called_once_with("foo")
+        mock_get_serial.assert_called_once_with(timeout=2.5)
 
 
 def test_main_serial() -> None:


### PR DESCRIPTION
### Motivation
- The CLI accepts a `--timeout` value but the auto-detection path did not forward `args.timeout` to `MicroBitSerial.get_serial()`, so discovery could ignore the configured timeout.

### Description
- Update `_run_command` to call `MicroBitSerial.get_serial(timeout=args.timeout)` when `--serial` is not provided.
- Add tests to `tests/test_main.py` to assert the default timeout (`10`) is forwarded to discovery and that a custom timeout (e.g. `--timeout 2.5`) is also forwarded.
- Files changed: `microfs/main.py` and `tests/test_main.py`.

### Testing
- Ran `ruff check .` which completed with no issues.
- Ran `pytest -q` which returned `52 passed` and exited successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992acb667cc8320b55042f6f0d08684)